### PR TITLE
Update robb-smarrt-8-switch-ROB_200-007-0.yaml - fix long press of 'off' buttons

### DIFF
--- a/automation/robb-smarrt-8-switch-ROB_200-007-0.yaml
+++ b/automation/robb-smarrt-8-switch-ROB_200-007-0.yaml
@@ -136,7 +136,15 @@ action:
       - condition:
         - '{{ mode == "MoveMode.Up" }}'
       then: !input on_button_1_long
-      else: !input off_button_1_long
+  - conditions:
+    - '{{ button == 1 and cmd == "move" }}'
+    sequence:
+    - variables:
+        mode: '{{ trigger.event.data.params.move_mode }}'
+    - if:
+      - condition:
+        - '{{ mode == "MoveMode.Down" }}'
+      then: !input off_button_1_long
   - conditions:
     - '{{ button == 2 and cmd == "on" }}'
     sequence: !input on_button_2_short
@@ -152,7 +160,15 @@ action:
       - condition:
         - '{{ mode == "MoveMode.Up" }}'
       then: !input on_button_2_long
-      else: !input off_button_2_long
+  - conditions:
+    - '{{ button == 2 and cmd == "move" }}'
+    sequence:
+    - variables:
+        mode: '{{ trigger.event.data.params.move_mode }}'
+    - if:
+      - condition:
+        - '{{ mode == "MoveMode.Down" }}'
+      then: !input off_button_2_long
   - conditions:
     - '{{ button == 3 and cmd == "on" }}'
     sequence: !input on_button_3_short
@@ -168,7 +184,15 @@ action:
       - condition:
         - '{{ mode == "MoveMode.Up" }}'
       then: !input on_button_3_long
-      else: !input off_button_3_long
+  - conditions:
+    - '{{ button == 3 and cmd == "move" }}'
+    sequence:
+    - variables:
+        mode: '{{ trigger.event.data.params.move_mode }}'
+    - if:
+      - condition:
+        - '{{ mode == "MoveMode.Down" }}'
+      then: !input off_button_3_long
   - conditions:
     - '{{ button == 4 and cmd == "on" }}'
     sequence: !input on_button_4_short
@@ -184,4 +208,12 @@ action:
       - condition:
         - '{{ mode == "MoveMode.Up" }}'
       then: !input on_button_4_long
-      else: !input off_button_4_long
+  - conditions:
+    - '{{ button == 4 and cmd == "move" }}'
+    sequence:
+    - variables:
+        mode: '{{ trigger.event.data.params.move_mode }}'
+    - if:
+      - condition:
+        - '{{ mode == "MoveMode.Down" }}'
+      then: !input off_button_4_long


### PR DESCRIPTION
Thanks for the blueprint first off, very helpfull!

The long press of the off buttons is not working. The event that is fired is 'move' not 'move_with_on_off'. I made changes to include that test and also test for 'mode == MoveMode.Down'. It works for me now but probably the community may benefit from this as well.

Perhaps the events fired by the Robb buttons changed causing the test to break?

Let me know what you think.

Johan