### PR TITLE
add handling of "on" event to ROB_200-016-0

### DIFF
--- a/automation/robb-smarrt-rgbw-remote-ROB_200-016-0.yaml
+++ b/automation/robb-smarrt-rgbw-remote-ROB_200-016-0.yaml
@@ -268,6 +268,30 @@ action:
           data:
              brightness_step: 13
 
+  # Switch light on
+  - conditions:
+    - '{{ cmd == "on" }}'
+    sequence:
+    - choose:
+      - conditions:
+        - '{{ group == 1 }}'
+        sequence:
+        - service: light.turn_on
+          target:
+             entity_id: !input light_group_1
+      - conditions:
+        - '{{ group == 2 }}'
+        sequence:
+        - service: light.turn_on
+          target:
+             entity_id: !input light_group_2
+      - conditions:
+        - '{{ group == 3 }}'
+        sequence:
+        - service: light.turn_on
+          target:
+             entity_id: !input light_group_3
+
   # Switch light off
   - conditions:
     - '{{ cmd == "off" }}'
@@ -291,7 +315,6 @@ action:
         - service: light.turn_off
           target:
              entity_id: !input light_group_3
-
   
   # Update light light level - step down
   - conditions:


### PR DESCRIPTION
i just bought a ROB_200-016-0, and this blueprint has been really nice to get started. One strange thing though is that my remote seems to send alternatively "on" or "off" each time i press the on/off button, and the blueprint handle only "off", meaning every other time it turns off the light, and every other time it does nothing. This PR adds handling for that "on" event